### PR TITLE
Fix tuna roll secret

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,28 +8,28 @@
       "name": "machikoro",
       "version": "0.2.0",
       "dependencies": {
-        "boardgame.io": "0.50.2",
-        "classnames": "2.3.2",
-        "koa-static": "5.0.0",
-        "lodash": "4.17.21",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "react-scripts": "5.0.1",
-        "ts-node": "10.9.1",
-        "ts-node-dev": "2.0.0",
-        "typescript": "4.9.5"
+        "boardgame.io": "^0.50.2",
+        "classnames": "^2.3.2",
+        "koa-static": "^5.0.0",
+        "lodash": "^4.17.21",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "react-scripts": "^5.0.1",
+        "ts-node": "^10.9.1",
+        "ts-node-dev": "^2.0.0",
+        "typescript": "^4.9.5"
       },
       "devDependencies": {
-        "@types/koa-static": "4.0.2",
-        "@types/lodash": "4.14.191",
-        "@types/node": "18.11.19",
-        "@types/react": "18.0.27",
-        "@types/react-dom": "18.0.10",
-        "@typescript-eslint/eslint-plugin": "5.50.0",
-        "@typescript-eslint/parser": "5.50.0",
-        "eslint": "8.33.0",
-        "eslint-plugin-react": "7.32.2",
-        "prettier": "2.8.3"
+        "@types/koa-static": "^4.0.2",
+        "@types/lodash": "^4.14.191",
+        "@types/node": "^18.11.19",
+        "@types/react": "^18.0.27",
+        "@types/react-dom": "^18.0.10",
+        "@typescript-eslint/eslint-plugin": "^5.50.0",
+        "@typescript-eslint/parser": "^5.50.0",
+        "eslint": "^8.33.0",
+        "eslint-plugin-react": "^7.32.2",
+        "prettier": "^2.8.3"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/game/establishments/index.ts
+++ b/src/game/establishments/index.ts
@@ -1,6 +1,7 @@
 //
 // Utility functions for establishments.
 //
+
 import * as Meta from './metadata';
 import { EstColor, EstType, Establishment, _EstablishmentData } from './types';
 import { Expansion, MachikoroG, SupplyVariant } from '../types';

--- a/src/game/machikoro.ts
+++ b/src/game/machikoro.ts
@@ -165,7 +165,7 @@ export const canDoOfficeGive = (G: MachikoroG, ctx: Ctx, est: Establishment): bo
  * @param opponent
  * @param est
  * @returns True if the current player can take the opponent's establishment,
- * as the second phase of the office action.
+ * as a part of the office action.
  */
 export const canDoOfficeTake = (G: MachikoroG, ctx: Ctx, opponent: number, est: Establishment): boolean => {
   const player = parseInt(ctx.currentPlayer);

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -16,7 +16,6 @@ import { _LandmarkData } from './landmarks/types';
  * @param officeGiveEst - the establishment picked for the office to give.
  * @param justBoughtEst - the establishment just bought (for prettier rendering).
  * @param tunaRoll - the roll made for the tuna boat.
- * @param tunaHasRolled - true if the tuna boat has rolled.
  * @param secret - game state that is not passed to clients.
  * @param _coins - coins for each player. (Private, do not access)
  * @param _estData - establishment data. (Private, do not access)
@@ -35,7 +34,7 @@ export type MachikoroG = {
   doOffice: boolean;
   officeGiveEst: Establishment | null;
   justBoughtEst: Establishment | null;
-  tunaHasRolled: boolean;
+  tunaRoll: number | null;
   secret: Secrets;
   _coins: number[];
   _estData: _EstablishmentData | null;
@@ -45,11 +44,9 @@ export type MachikoroG = {
 
 /**
  * Game state that is not passed to the clients
- * @param tunaRoll - the roll made for the tuna boat.
  * @param _decks - the establishment draw decks. (Private, do not access)
  */
 export type Secrets = {
-  tunaRoll: number | null;
   _decks: Establishment[][] | null;
 };
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -35,7 +35,6 @@ export type MachikoroG = {
   doOffice: boolean;
   officeGiveEst: Establishment | null;
   justBoughtEst: Establishment | null;
-  tunaRoll: number | null; // TODO: make secret
   tunaHasRolled: boolean;
   secret: Secrets;
   _coins: number[];
@@ -46,9 +45,11 @@ export type MachikoroG = {
 
 /**
  * Game state that is not passed to the clients
+ * @param tunaRoll - the roll made for the tuna boat.
  * @param _decks - the establishment draw decks. (Private, do not access)
  */
 export type Secrets = {
+  tunaRoll: number | null;
   _decks: Establishment[][] | null;
 };
 


### PR DESCRIPTION
Previously the tuna roll was not a secret, so it was possible (in principle) to know its value. This PR reverts to the old behavior where the tuna roll is made only when it is needed.