### PR TITLE
Rename `Office` to `Business Center`

### DIFF
--- a/src/game/establishments/metadata.ts
+++ b/src/game/establishments/metadata.ts
@@ -94,7 +94,7 @@ export const TVStation: Establishment = {
 
 export const Office: Establishment = {
   _id: 8,
-  name: 'Office',
+  name: 'Business Center',
   description: 'Exchange a non-Purple establishment with another player.',
   cost: 8,
   earnings: 0,


### PR DESCRIPTION
`Business Center` is the official name of the card. Not sure why Yucata used `Office`.

This only changes the UI name. The internal name will stay as `Office`.