### PR TITLE
Fix room refresh & player name display

### DIFF
--- a/src/lobby/Room.tsx
+++ b/src/lobby/Room.tsx
@@ -142,7 +142,7 @@ export default class Room extends React.Component<RoomProps, RoomState> {
 
     this.props.clearErrorMessage();
 
-    this.fetchInterval = setInterval(() => void this.fetchMatch, updateIntervalMs);
+    this.fetchInterval = setInterval(() => void this.fetchMatch(), updateIntervalMs);
     void this.fetchMatch();
   }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -522,6 +522,7 @@ select {
   font-size: 14px;
   overflow: hidden;
   width: 90px;
+  height: 16px;
 }
 
 .name_do_tv {


### PR DESCRIPTION
- Fix match information not refreshing in Room
- Fix player name in-game: no longer creates multiple lines and has fixed height.