### PR TITLE
Fix: Shopping District and Exhibit Hall coin activation

### DIFF
--- a/src/game/establishments/metadata2.ts
+++ b/src/game/establishments/metadata2.ts
@@ -193,7 +193,7 @@ export const TaxOffice2: Establishment = {
   name: 'Shopping District',
   description: 'From each opponent who has more than 10 coins, take half, rounded down.',
   cost: 3,
-  earn: 10, // This is not the coins taken, but the threshold for triggering the tax office
+  earn: 11, // This is not the coins taken, but the threshold for triggering the tax office
   rolls: [8, 9],
   color: EstColor.Purple,
   type: null,

--- a/src/game/landmarks/metadata2.ts
+++ b/src/game/landmarks/metadata2.ts
@@ -139,7 +139,7 @@ export const ExhibitHall2: Landmark = {
   name: 'Exhibit Hall',
   miniName: 'Exhibit Hall',
   description: 'From each opponent who has more than 10 coins, take half, rounded down (builder only).',
-  coins: 10, // This is not the coins taken, but the threshold for triggering the tax office
+  coins: 11, // This is not the coins taken, but the threshold for triggering the tax office
   cost: [12, 16, 22],
 };
 


### PR DESCRIPTION
These cards should not activate on 10 coins.