### PR TITLE
End game immediately after win condition

### DIFF
--- a/src/game/machikoro.ts
+++ b/src/game/machikoro.ts
@@ -605,6 +605,7 @@ const switchState = (context: FnContext<MachikoroG>): void => {
     // first, check if game is over
     if (canEndGame(G, ctx)) {
       endGame(context, player);
+      return;
     }
 
     activateBoughtLand(context);


### PR DESCRIPTION
Certain landmarks were still being activated after the game had already ended (e.g. French Restaurant). This PR ends the game immediately once a player wins.

This change is more aesthetic than functional, since nothing in the actual game has changed.