### PR TITLE
Proposed solution to NODE_PATH issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "boardgame.io": "^0.50.2",
         "classnames": "^2.3.2",
+        "cross-env": "^7.0.3",
         "genversion": "^3.1.1",
         "koa-static": "^5.0.0",
         "react": "^18.2.0",
@@ -5608,6 +5609,23 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "boardgame.io": "^0.50.2",
     "classnames": "^2.3.2",
+    "cross-env": "^7.0.3",
     "genversion": "^3.1.1",
     "koa-static": "^5.0.0",
     "react": "^18.2.0",
@@ -18,8 +19,8 @@
     "prebuild": "npm run version:fix",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "serve:dev": "NODE_PATH=./src ts-node-dev ./src/server/index.ts",
-    "serve:prod": "NODE_PATH=./src ts-node --transpileOnly ./src/server/index.ts",
+    "serve:dev": "cross-env NODE_PATH=./src ts-node-dev ./src/server/index.ts",
+    "serve:prod": "cross-env NODE_PATH=./src ts-node --transpileOnly ./src/server/index.ts",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "prettier": "prettier --check .",


### PR DESCRIPTION
Proposed solution to #98.

1. Information related to the `cross-env` package was added to `package-lock.json`.
2. Updated `serve:dev` and `serve:prod` commands to use `cross-env` in order to identify the `NODE_PATH` keyword.

Now we have to check that it works and does not negatively affect users on the other OS systems (Mac/Linux).
- [x] Windows @AquaDragon 
- [x] macOS @kevinddchen 
- [ ] Linux