### PR TITLE
Fix Tax Office description

### DIFF
--- a/src/game/establishments/metadata.ts
+++ b/src/game/establishments/metadata.ts
@@ -322,7 +322,7 @@ export const TaxOffice: Establishment = {
   _id: 24,
   _ver: Version.MK1,
   name: 'Tax Office',
-  description: 'From each opponent who has more than 10 coins, take half, rounded down.',
+  description: 'From each opponent who has 10 or more coins, take half, rounded down.',
   cost: 4,
   earn: 10, // This is not the coins taken, but the threshold for triggering the tax office
   rolls: [8, 9],


### PR DESCRIPTION
The official translation for Tax Office for Machi Koro 1 says that this card activates on _10 or more_ coins. https://boardgamegeek.com/image/2466183/yeoster

This behavior is coded correctly, but the card description was not updated.