### PR TITLE
Add expansion toggle for Millionaire's Row

### DIFF
--- a/src/board/PlayerInfo.tsx
+++ b/src/board/PlayerInfo.tsx
@@ -40,7 +40,7 @@ export default class PlayerInfo extends React.Component<PlayerInfoProps, object>
 
   render() {
     const { G, ctx, moves, isActive, player, clientPlayer, name } = this.props;
-    const version = Game.expToVer(G.expansion);
+    const version = G.version;
     const currentPlayer = parseInt(ctx.currentPlayer);
     const money = Game.getCoins(G, player);
     const canDoTV = isActive && Game.canDoTV(G, ctx, player);

--- a/src/board/Supply.tsx
+++ b/src/board/Supply.tsx
@@ -34,7 +34,7 @@ export default class Supply extends React.Component<SupplyProps, object> {
   private renderLandTable = (): JSX.Element | null => {
     const { G, ctx, moves, isActive, clientPlayer } = this.props;
     // return nothing for Machi Koro 1.
-    if (Game.expToVer(G.expansion) === Game.Version.MK1) {
+    if (G.version === Game.Version.MK1) {
       return null;
     }
 

--- a/src/board/TextPanel/Logger.tsx
+++ b/src/board/TextPanel/Logger.tsx
@@ -4,8 +4,7 @@ import { BoardProps } from 'boardgame.io/react';
 import { LogEntry } from 'boardgame.io';
 import React from 'react';
 
-import { Expansion, Log, MachikoroG } from 'game';
-import { assertUnreachable } from 'common/typescript';
+import { Log, MachikoroG, Version, displayName } from 'game';
 
 /**
  * @extends BoardProps<MachikoroG>
@@ -91,11 +90,11 @@ export default class Logger extends React.Component<LogProps, object> {
     let lines: string[] = [];
 
     lines.push('Game Configuration:');
-    lines.push('– ' + this.expansionName(G.expansion) + ' (' + G.supplyVariant + ' Supply)');
+    lines.push('– ' + displayName(G.version, G.expansions) + ' (' + G.supplyVariant + ' Supply)');
     lines.push(' ');
 
     // for MK2, add a line to indicate the start of the initial build phase
-    if (G.expansion === Expansion.MK2) {
+    if (G.version === Version.MK2) {
       lines.push('(Start of initial build phase)');
     }
 
@@ -122,18 +121,6 @@ export default class Logger extends React.Component<LogProps, object> {
       }
     }
     return lines;
-  };
-
-  private expansionName = (expansion: Expansion): string => {
-    if (expansion === Expansion.Base) {
-      return 'Base Expansion';
-    } else if (expansion === Expansion.Harbor) {
-      return 'Harbor Expansion';
-    } else if (expansion === Expansion.MK2) {
-      return 'Machi Koro 2';
-    } else {
-      return assertUnreachable(expansion);
-    }
   };
 
   // --- React ----------------------------------------------------------------

--- a/src/game/display.ts
+++ b/src/game/display.ts
@@ -1,0 +1,87 @@
+//
+// Useful functions for displaying game-related text
+//
+
+import { assertUnreachable } from 'common/typescript';
+
+import { Expansion, Version, SupplyVariant } from './types';
+
+/**
+ * @param version
+ * @param expansions
+ * @returns Display name for version and expansion combination.
+ */
+export function displayName(version: Version | null, expansions: Expansion[] | null): string {
+  if (version === null || expansions === null) {
+    return '???';
+  }
+  if (version === Version.MK1) {
+    const harbor = expansions.includes(Expansion.Harbor);
+    const million = expansions.includes(Expansion.Million);
+    if (harbor && million) {
+      return "Harbor + Millionaire's Row Expansions";
+    } else if (harbor) {
+      return 'Harbor Expansion';
+    } else if (million) {
+      return "Millionaire's Row Expansion";
+    } else {
+      return 'Base Game';
+    }
+  } else if (version === Version.MK2) {
+    return 'Machi Koro 2';
+  } else {
+    return assertUnreachable(version);
+  }
+}
+
+/**
+ * @param version
+ * @returns Display name for version.
+ */
+export function versionName(version: Version | null): string {
+  if (version === null) {
+    return '???';
+  } else if (version === Version.MK1) {
+    return 'Machi Koro';
+  } else if (version === Version.MK2) {
+    return 'Machi Koro 2';
+  } else {
+    return assertUnreachable(version);
+  }
+}
+
+/**
+ * @param expansion
+ * @returns Display name for expansion.
+ */
+export function expansionName(expansion: Expansion | null): string {
+  if (expansion === null) {
+    return '???';
+  } else if (expansion === Expansion.Base) {
+    return 'Base Game';
+  } else if (expansion === Expansion.Harbor) {
+    return 'Harbor Expansion';
+  } else if (expansion === Expansion.Million) {
+    return 'Millionaire\'s Row Expansion';
+  } else {
+    return assertUnreachable(expansion);
+  }
+}
+
+/**
+ * @param supplyVariant
+ * @returns Display name for supply variant.
+ */
+export function supplyVariantName(supplyVariant: SupplyVariant | null): string {
+  if (supplyVariant === null) {
+    return '???';
+  } else if (supplyVariant === SupplyVariant.Hybrid) {
+    return 'Hybrid Supply';
+  } else if (supplyVariant === SupplyVariant.Variable) {
+    return 'Variable Supply';
+  } else if (supplyVariant === SupplyVariant.Total) {
+    return 'Total Supply';
+  } else {
+    return assertUnreachable(supplyVariant);
+  }
+}

--- a/src/game/display.ts
+++ b/src/game/display.ts
@@ -4,7 +4,7 @@
 
 import { assertUnreachable } from 'common/typescript';
 
-import { Expansion, Version, SupplyVariant } from './types';
+import { Expansion, SupplyVariant, Version } from './types';
 
 /**
  * @param version
@@ -62,7 +62,7 @@ export function expansionName(expansion: Expansion | null): string {
   } else if (expansion === Expansion.Harbor) {
     return 'Harbor Expansion';
   } else if (expansion === Expansion.Million) {
-    return 'Millionaire\'s Row Expansion';
+    return "Millionaire's Row Expansion";
   } else {
     return assertUnreachable(expansion);
   }

--- a/src/game/establishments/main.ts
+++ b/src/game/establishments/main.ts
@@ -70,7 +70,8 @@ export const isInUse = (G: MachikoroG, est: Establishment): boolean => {
  */
 export const countRemaining = (G: MachikoroG, est: Establishment): number => {
   if (G.version !== est._ver) {
-    throw new Error(`Establishment id=${est._id} ver=${est._ver} does not match the game version, ${G.version}.`);
+    console.warn(`Establishment id=${est._id} ver=${est._ver} does not match the game version, ${G.version}.`);
+    return 0;
   }
   assertEstDataExists(G);
   return G._estData.remainingCount[est._id];
@@ -84,7 +85,8 @@ export const countRemaining = (G: MachikoroG, est: Establishment): number => {
  */
 export const countAvailable = (G: MachikoroG, est: Establishment): number => {
   if (G.version !== est._ver) {
-    throw new Error(`Establishment id=${est._id} ver=${est._ver} does not match the game version, ${G.version}.`);
+    console.warn(`Establishment id=${est._id} ver=${est._ver} does not match the game version, ${G.version}.`);
+    return 0;
   }
   assertEstDataExists(G);
   return G._estData.availableCount[est._id];
@@ -99,7 +101,8 @@ export const countAvailable = (G: MachikoroG, est: Establishment): number => {
  */
 export const countOwned = (G: MachikoroG, player: number, est: Establishment): number => {
   if (G.version !== est._ver) {
-    throw new Error(`Establishment id=${est._id} ver=${est._ver} does not match the game version, ${G.version}.`);
+    console.warn(`Establishment id=${est._id} ver=${est._ver} does not match the game version, ${G.version}.`);
+    return 0;
   }
   assertEstDataExists(G);
   return G._estData.ownedCount[est._id][player];

--- a/src/game/establishments/metadata.ts
+++ b/src/game/establishments/metadata.ts
@@ -3,11 +3,12 @@
 //
 
 import { EstColor, EstType, Establishment } from './types';
-import { Version } from '../types';
+import { Expansion, Version } from '../types';
 
 export const SushiBar: Establishment = {
   _id: 0,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Sushi Bar',
   description: 'If you have a "Harbor", take 3 coins from the player who just rolled.',
   cost: 2,
@@ -21,6 +22,7 @@ export const SushiBar: Establishment = {
 export const WheatField: Establishment = {
   _id: 1,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Wheat Field',
   description: 'Receive 1 coin from the bank.',
   cost: 1,
@@ -34,6 +36,7 @@ export const WheatField: Establishment = {
 export const Ranch: Establishment = {
   _id: 2,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Ranch',
   description: 'Receive 1 coin from the bank.',
   cost: 1,
@@ -47,6 +50,7 @@ export const Ranch: Establishment = {
 export const Bakery: Establishment = {
   _id: 3,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Bakery',
   description: 'Receive 1 coin from the bank.',
   cost: 1,
@@ -60,6 +64,7 @@ export const Bakery: Establishment = {
 export const Cafe: Establishment = {
   _id: 4,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Café',
   description: 'Take 1 coin from the player who just rolled.',
   cost: 2,
@@ -73,6 +78,7 @@ export const Cafe: Establishment = {
 export const FlowerGarden: Establishment = {
   _id: 5,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Flower Garden',
   description: 'Receive 1 coin from the bank.',
   cost: 2,
@@ -86,6 +92,7 @@ export const FlowerGarden: Establishment = {
 export const ConvenienceStore: Establishment = {
   _id: 6,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Convenience Store',
   description: 'Receive 3 coins from the bank.',
   cost: 2,
@@ -99,6 +106,7 @@ export const ConvenienceStore: Establishment = {
 export const Forest: Establishment = {
   _id: 7,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Forest',
   description: 'Receive 1 coin from the bank.',
   cost: 3,
@@ -112,6 +120,7 @@ export const Forest: Establishment = {
 export const FlowerShop: Establishment = {
   _id: 8,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Flower Shop',
   description: 'Receive 1 coin from the bank for each "Flower Garden" establishment you own.',
   cost: 1,
@@ -125,6 +134,7 @@ export const FlowerShop: Establishment = {
 export const PizzaJoint: Establishment = {
   _id: 9,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Pizza Joint',
   description: 'Take 1 coin from the player who just rolled.',
   cost: 1,
@@ -138,6 +148,7 @@ export const PizzaJoint: Establishment = {
 export const CheeseFactory: Establishment = {
   _id: 10,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Cheese Factory',
   description: 'Receive 3 coins from the bank for each ' + EstType.Animal + ' establishment you own.',
   cost: 5,
@@ -151,6 +162,7 @@ export const CheeseFactory: Establishment = {
 export const HamburgerStand: Establishment = {
   _id: 11,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Hamburger Stand',
   description: 'Take 1 coin from the player who just rolled.',
   cost: 1,
@@ -164,6 +176,7 @@ export const HamburgerStand: Establishment = {
 export const MackerelBoat: Establishment = {
   _id: 12,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Mackerel Boat',
   description: 'If you have a "Harbor", receive 3 coins from the bank.',
   cost: 2,
@@ -177,6 +190,7 @@ export const MackerelBoat: Establishment = {
 export const FurnitureFactory: Establishment = {
   _id: 13,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Furniture Factory',
   description: 'Receive 3 coins from the bank for each ' + EstType.Gear + ' establishment you own.',
   cost: 3,
@@ -190,6 +204,7 @@ export const FurnitureFactory: Establishment = {
 export const Mine: Establishment = {
   _id: 14,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Mine',
   description: 'Receive 5 coins from the bank.',
   cost: 6,
@@ -203,6 +218,7 @@ export const Mine: Establishment = {
 export const FamilyRestaurant: Establishment = {
   _id: 15,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Family Restaurant',
   description: 'Take 2 coins from the player who just rolled.',
   cost: 3,
@@ -216,6 +232,7 @@ export const FamilyRestaurant: Establishment = {
 export const AppleOrchard: Establishment = {
   _id: 16,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Apple Orchard',
   description: 'Receive 3 coins from the bank.',
   cost: 3,
@@ -229,6 +246,7 @@ export const AppleOrchard: Establishment = {
 export const FarmersMarket: Establishment = {
   _id: 17,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Farmers Market',
   description: 'Receive 2 coins from the bank for each ' + EstType.Wheat + ' establishment you own.',
   cost: 2,
@@ -242,6 +260,7 @@ export const FarmersMarket: Establishment = {
 export const FoodWarehouse: Establishment = {
   _id: 18,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Food Warehouse',
   description: 'Receive 2 coins from the bank for each ' + EstType.Cup + ' establishment you own.',
   cost: 2,
@@ -255,6 +274,7 @@ export const FoodWarehouse: Establishment = {
 export const TunaBoat: Establishment = {
   _id: 19,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Tuna Boat',
   description: 'Roll 2 dice. If you have a "Harbor", receive as many coins as the dice total from the bank.',
   cost: 5,
@@ -268,6 +288,7 @@ export const TunaBoat: Establishment = {
 export const Stadium: Establishment = {
   _id: 20,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Stadium',
   description: 'Take 2 coins from each opponent.',
   cost: 6,
@@ -281,6 +302,7 @@ export const Stadium: Establishment = {
 export const TVStation: Establishment = {
   _id: 21,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'TV Station',
   description: 'Take 5 coins from an opponent of your choice.',
   cost: 7,
@@ -294,6 +316,7 @@ export const TVStation: Establishment = {
 export const Office: Establishment = {
   _id: 22,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Business Center',
   description: 'Exchange a non-Major establishment with an opponent.',
   cost: 8,
@@ -307,6 +330,7 @@ export const Office: Establishment = {
 export const Publisher: Establishment = {
   _id: 23,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Publisher',
   description:
     'Take 1 coin from each opponent for each ' + EstType.Cup + ' and ' + EstType.Shop + ' establishment they own.',
@@ -321,6 +345,7 @@ export const Publisher: Establishment = {
 export const TaxOffice: Establishment = {
   _id: 24,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Tax Office',
   description: 'From each opponent who has 10 or more coins, take half, rounded down.',
   cost: 4,
@@ -365,53 +390,16 @@ export const _ESTABLISHMENTS = [
 /**
  * Establishments used in the Base expansion.
  */
-export const _BASE_ESTABLISHMENTS = [
-  WheatField._id,
-  Ranch._id,
-  Bakery._id,
-  Cafe._id,
-  ConvenienceStore._id,
-  Forest._id,
-  CheeseFactory._id,
-  FurnitureFactory._id,
-  Mine._id,
-  FamilyRestaurant._id,
-  AppleOrchard._id,
-  FarmersMarket._id,
-  Stadium._id,
-  TVStation._id,
-  Office._id,
-];
+export const _BASE_ESTABLISHMENTS = _ESTABLISHMENTS.filter((est) => est._exp === Expansion.Base).map((est) => est._id);
 
 /**
- * Establishments used in the Harbor expansion.
+ * Establishments added in the Harbor expansion.
  */
-export const _HARBOR_ESTABLISHMENTS = _ESTABLISHMENTS.map((est) => est._id);
+export const _HARBOR_ESTABLISHMENTS = _ESTABLISHMENTS
+  .filter((est) => est._exp === Expansion.Harbor)
+  .map((est) => est._id);
 
 /**
  * Establishments a player starts with in Machi Koro 1.
  */
 export const _STARTING_ESTABLISHMENTS = [WheatField._id, Bakery._id];
-
-/**
- * Maximum number of unique establishments in the supply for Variable Supply.
- */
-export const _VARIABLE_SUPPLY_LIMIT = 10;
-
-/**
- * Maximum number of unique establishments that activate with rolls <= 6 in the
- * supply for Hybrid Supply.
- */
-export const _HYBRID_SUPPY_LIMIT_LOWER = 5;
-
-/**
- * Maximum number of unique establishments that activate with rolls > 6 in the
- * supply for Hybrid Supply.
- */
-export const _HYBRID_SUPPY_LIMIT_UPPER = 5;
-
-/**
- * Maximum number of unique major (purple) establishments in the supply for
- * Hybrid Supply.
- */
-export const _HYBRID_SUPPY_LIMIT_MAJOR = 2;

--- a/src/game/establishments/metadata2.ts
+++ b/src/game/establishments/metadata2.ts
@@ -3,11 +3,12 @@
 //
 
 import { EstColor, EstType, Establishment } from './types';
-import { Version } from '../types';
+import { Expansion, Version } from '../types';
 
 export const SushiBar2: Establishment = {
   _id: 0,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Sushi Bar',
   description: 'Take 3 coins from the player who just rolled.',
   cost: 2,
@@ -21,6 +22,7 @@ export const SushiBar2: Establishment = {
 export const WheatField2: Establishment = {
   _id: 1,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Wheat Field',
   description: 'Receive 1 coin from the bank.',
   cost: 1,
@@ -34,6 +36,7 @@ export const WheatField2: Establishment = {
 export const Vineyard2: Establishment = {
   _id: 2,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Vineyard',
   description: 'Receive 2 coins from the bank.',
   cost: 1,
@@ -47,6 +50,7 @@ export const Vineyard2: Establishment = {
 export const Bakery2: Establishment = {
   _id: 3,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Bakery',
   description: 'Receive 2 coins from the bank.',
   cost: 1,
@@ -60,6 +64,7 @@ export const Bakery2: Establishment = {
 export const Cafe2: Establishment = {
   _id: 4,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Café',
   description: 'Take 2 coins from the player who just rolled.',
   cost: 1,
@@ -73,6 +78,7 @@ export const Cafe2: Establishment = {
 export const FlowerGarden2: Establishment = {
   _id: 5,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Flower Garden',
   description: 'Receive 2 coins from the bank.',
   cost: 2,
@@ -86,6 +92,7 @@ export const FlowerGarden2: Establishment = {
 export const ConvenienceStore2: Establishment = {
   _id: 6,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Convenience Store',
   description: 'Receive 3 coins from the bank.',
   cost: 1,
@@ -99,6 +106,7 @@ export const ConvenienceStore2: Establishment = {
 export const Forest2: Establishment = {
   _id: 7,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Forest',
   description: 'Receive 2 coins from the bank.',
   cost: 3,
@@ -112,6 +120,7 @@ export const Forest2: Establishment = {
 export const FlowerShop2: Establishment = {
   _id: 8,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Flower Shop',
   description: 'Receive 3 coins from the bank for each "Flower Garden" establishment you own.',
   cost: 1,
@@ -125,6 +134,7 @@ export const FlowerShop2: Establishment = {
 export const Office2: Establishment = {
   _id: 9,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Business Center',
   description: 'You may exchange an establishment with an opponent.',
   cost: 3,
@@ -138,6 +148,7 @@ export const Office2: Establishment = {
 export const CornField2: Establishment = {
   _id: 10,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Corn Field',
   description: 'Receive 3 coins from the bank.',
   cost: 2,
@@ -151,6 +162,7 @@ export const CornField2: Establishment = {
 export const Stadium2: Establishment = {
   _id: 11,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Stadium',
   description: 'Take 3 coins from each opponent.',
   cost: 3,
@@ -164,6 +176,7 @@ export const Stadium2: Establishment = {
 export const HamburgerStand2: Establishment = {
   _id: 12,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Hamburger Stand',
   description: 'Take 2 coins from the player who just rolled.',
   cost: 1,
@@ -177,6 +190,7 @@ export const HamburgerStand2: Establishment = {
 export const FurnitureFactory2: Establishment = {
   _id: 13,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Furniture Factory',
   description: 'Receive 4 coins from the bank for each ' + EstType.Gear + ' establishment you own.',
   cost: 4,
@@ -190,6 +204,7 @@ export const FurnitureFactory2: Establishment = {
 export const TaxOffice2: Establishment = {
   _id: 14,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Shopping District',
   description: 'From each opponent who has more than 10 coins, take half, rounded down.',
   cost: 3,
@@ -203,6 +218,7 @@ export const TaxOffice2: Establishment = {
 export const FamilyRestaurant2: Establishment = {
   _id: 15,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Family Restaurant',
   description: 'Take 2 coins from the player who just rolled.',
   cost: 2,
@@ -216,6 +232,7 @@ export const FamilyRestaurant2: Establishment = {
 export const Winery2: Establishment = {
   _id: 16,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Winery',
   description: 'Receive 3 coins from the bank for each ' + EstType.Fruit + ' establishment you own.',
   cost: 3,
@@ -229,6 +246,7 @@ export const Winery2: Establishment = {
 export const AppleOrchard2: Establishment = {
   _id: 17,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Apple Orchard',
   description: 'Receive 3 coins from the bank.',
   cost: 1,
@@ -242,6 +260,7 @@ export const AppleOrchard2: Establishment = {
 export const FoodWarehouse2: Establishment = {
   _id: 18,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Food Warehouse',
   description: 'Receive 2 coins from the bank for each ' + EstType.Cup + ' establishment you own.',
   cost: 2,
@@ -255,6 +274,7 @@ export const FoodWarehouse2: Establishment = {
 export const Mine2: Establishment = {
   _id: 19,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Mine',
   description: 'Receive 6 coins from the bank.',
   cost: 4,

--- a/src/game/establishments/types.ts
+++ b/src/game/establishments/types.ts
@@ -2,7 +2,7 @@
 // Types for establishments.
 //
 
-import type { Version } from '../types';
+import type { Expansion, Version } from '../types';
 
 /**
  * Interface for establishment metadata.
@@ -15,6 +15,7 @@ import type { Version } from '../types';
  * @prop {EstType|null} type - The type of the establishment (for combos, e.g. 'Animal').
  * @prop {number} _id - Unique id used to enumerate establishments.
  * @prop {Version} _ver - Used to distinguish Machi Koro 1 and 2 establishments.
+ * @prop {Expansion} _exp - For Machi Koro 1, the expansion the establishment belongs to.
  * @prop {number|null} _initial - The number of copies in the initial supply.
  * If null, then is equal to the number of players.
  */
@@ -28,6 +29,7 @@ export interface Establishment {
   readonly type: EstType | null;
   readonly _id: number;
   readonly _ver: Version;
+  readonly _exp: Expansion;
   readonly _initial: number | null;
 }
 

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -1,3 +1,4 @@
+export * from './display';
 export * from './machikoro';
 export * from './types';
 export * as Est from './establishments';

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -1,6 +1,5 @@
 export * from './machikoro';
 export * from './types';
-export { expToVer } from './utils';
 export * as Est from './establishments';
 export * as Land from './landmarks';
 export * as Log from './log';

--- a/src/game/landmarks/main.ts
+++ b/src/game/landmarks/main.ts
@@ -48,7 +48,8 @@ export const isInUse = (G: MachikoroG, land: Landmark): boolean => {
  */
 export const isAvailable = (G: MachikoroG, land: Landmark): boolean => {
   if (G.version !== land._ver) {
-    throw new Error(`Landmark id=${land._id} ver=${land._ver} does not match the game version, ${G.version}.`);
+    console.warn(`Landmark id=${land._id} ver=${land._ver} does not match the game version, ${G.version}.`);
+    return false;
   }
   assertLandDataExists(G);
   return G._landData.available[land._id];
@@ -62,7 +63,7 @@ export const isAvailable = (G: MachikoroG, land: Landmark): boolean => {
  */
 export const owns = (G: MachikoroG, player: number, land: Landmark): boolean => {
   if (G.version !== land._ver) {
-    // this is used often for hard-coded landmarks, so no need to throw error
+    // this is used often for hard-coded landmarks, so no need to warn
     return false;
   }
   assertLandDataExists(G);
@@ -76,7 +77,7 @@ export const owns = (G: MachikoroG, player: number, land: Landmark): boolean => 
  */
 export const isOwned = (G: MachikoroG, land: Landmark): boolean => {
   if (G.version !== land._ver) {
-    // this is used often for hard-coded landmarks, so no need to throw error
+    // this is used often for hard-coded landmarks, so no need to warn
     return false;
   }
   assertLandDataExists(G);

--- a/src/game/landmarks/main.ts
+++ b/src/game/landmarks/main.ts
@@ -89,7 +89,7 @@ export const isOwned = (G: MachikoroG, land: Landmark): boolean => {
  * @returns
  */
 const getAll = (G: MachikoroG): Landmark[] => {
-  const version = G.version
+  const version = G.version;
   if (version === Version.MK1) {
     return Meta._LANDMARKS;
   } else if (version === Version.MK2) {
@@ -146,7 +146,7 @@ export const countBuilt = (G: MachikoroG, player: number): number => {
  * @returns The cost of the landmark for the player.
  */
 export const cost = (G: MachikoroG, land: Landmark, player: number): number => {
-  const { version } = G;
+  const version = G.version;
   const landCostArray = costArray(G, land, player);
   if (version === Version.MK1) {
     // Machi Koro 1 only has one cost
@@ -192,7 +192,7 @@ export const costArray = (G: MachikoroG, land: Landmark, player: number | null):
  * @param land
  */
 export const buy = (G: MachikoroG, player: number, land: Landmark): void => {
-  const { version } = G;
+  const version = G.version;
   if (version !== land._ver) {
     throw new Error(`Landmark id=${land._id} ver=${land._ver} does not match the game version, ${G.version}.`);
   }

--- a/src/game/landmarks/metadata.ts
+++ b/src/game/landmarks/metadata.ts
@@ -2,9 +2,9 @@
 // Game metadata for landmarks.
 //
 
+import { Expansion, Version } from '../types';
 import { EstType } from '../establishments/types';
 import { Landmark } from './types';
-import { Expansion, Version } from '../types';
 
 export const CityHall: Landmark = {
   _id: 0,

--- a/src/game/landmarks/metadata.ts
+++ b/src/game/landmarks/metadata.ts
@@ -4,11 +4,12 @@
 
 import { EstType } from '../establishments/types';
 import { Landmark } from './types';
-import { Version } from '../types';
+import { Expansion, Version } from '../types';
 
 export const CityHall: Landmark = {
   _id: 0,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'City Hall',
   miniName: 'City Hall',
   description: 'Immediately before buying establishments, if you have 0 coins, receive 1 coin from the bank.',
@@ -19,6 +20,7 @@ export const CityHall: Landmark = {
 export const Harbor: Landmark = {
   _id: 1,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Harbor',
   miniName: 'Harbor',
   description: 'If the dice total is 10 or more, you may add 2 to the total.',
@@ -29,6 +31,7 @@ export const Harbor: Landmark = {
 export const TrainStation: Landmark = {
   _id: 2,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Train Station',
   miniName: 'Train Station',
   description: 'You may roll 2 dice.',
@@ -39,6 +42,7 @@ export const TrainStation: Landmark = {
 export const ShoppingMall: Landmark = {
   _id: 3,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Shopping Mall',
   miniName: 'Shopping Mall',
   description: 'Your ' + EstType.Cup + ' and ' + EstType.Shop + ' establishments earn +1 coin when activated.',
@@ -49,6 +53,7 @@ export const ShoppingMall: Landmark = {
 export const AmusementPark: Landmark = {
   _id: 4,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Amusement Park',
   miniName: 'Amuse. Park',
   description: 'If you roll doubles, take another turn after this one.',
@@ -59,6 +64,7 @@ export const AmusementPark: Landmark = {
 export const RadioTower: Landmark = {
   _id: 5,
   _ver: Version.MK1,
+  _exp: Expansion.Base,
   name: 'Radio Tower',
   miniName: 'Radio Tower',
   description: 'Once per turn, you may roll again.',
@@ -69,6 +75,7 @@ export const RadioTower: Landmark = {
 export const Airport: Landmark = {
   _id: 6,
   _ver: Version.MK1,
+  _exp: Expansion.Harbor,
   name: 'Airport',
   miniName: 'Airport',
   description: 'If you build nothing on your turn, receive 10 coins from the bank.',
@@ -84,19 +91,14 @@ export const _LANDMARKS = [CityHall, Harbor, TrainStation, ShoppingMall, Amuseme
 /**
  * Landmarks used in the Base expansion.
  */
-export const _BASE_LANDMARKS = [TrainStation._id, ShoppingMall._id, AmusementPark._id, RadioTower._id];
+export const _BASE_LANDMARKS = _LANDMARKS.filter((land) => land._exp === Expansion.Base).map((land) => land._id);
 
 /**
- * Landmarks used in the Harbor expansion.
+ * Landmarks added in the Harbor expansion.
  */
-export const _HARBOR_LANDMARKS = _LANDMARKS.map((landmark) => landmark._id);
+export const _HARBOR_LANDMARKS = _LANDMARKS.filter((land) => land._exp === Expansion.Harbor).map((land) => land._id);
 
 /**
- * Landmarks a player starts with in the Base expansion.
- */
-export const _BASE_STARTING_LANDMARKS: number[] = [];
-
-/**
- * Landmarks a player starts with in the Harbor expansion.
+ * Additional landmarks a player starts with in the Harbor expansion.
  */
 export const _HARBOR_STARTING_LANDMARKS = [CityHall._id];

--- a/src/game/landmarks/metadata2.ts
+++ b/src/game/landmarks/metadata2.ts
@@ -4,7 +4,7 @@
 
 import { EstType } from '../establishments/types';
 import { Landmark } from './types';
-import { Version } from '../types';
+import { Expansion, Version } from '../types';
 
 /**
  * Number of landmarks required to win the game.
@@ -14,6 +14,7 @@ export const MK2_LANDMARKS_TO_WIN = 3;
 export const CityHall2: Landmark = {
   _id: 0,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'City Hall',
   miniName: 'City Hall',
   description: 'Immediately before buying establishments, if you have 0 coins, receive 1 coin from the bank.',
@@ -24,6 +25,7 @@ export const CityHall2: Landmark = {
 export const LoanOffice2: Landmark = {
   _id: 1,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Loan Office',
   miniName: 'Loan Office',
   description:
@@ -36,6 +38,7 @@ export const LoanOffice2: Landmark = {
 export const FarmersMarket2: Landmark = {
   _id: 2,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Farmers Market',
   miniName: 'Farmers Mkt.',
   description: 'Your ' + EstType.Wheat + ' establishments earn +1 coin when activated (all players).',
@@ -46,6 +49,7 @@ export const FarmersMarket2: Landmark = {
 export const FrenchRestaurant2: Landmark = {
   _id: 3,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'French Restaurant',
   miniName: 'French Rest.',
   description: 'Take 2 coins from each opponent (builder only).',
@@ -56,6 +60,7 @@ export const FrenchRestaurant2: Landmark = {
 export const MovingCompany2: Landmark = {
   _id: 4,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Moving Company',
   miniName: 'Moving Co.',
   description: 'If you roll doubles, give 1 establishment to the previous player (all players).',
@@ -66,6 +71,7 @@ export const MovingCompany2: Landmark = {
 export const Observatory2: Landmark = {
   _id: 5,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Observatory',
   miniName: 'Observatory',
   description: 'Reduce the build cost of "Launch Pad" by 5 coins (all players).',
@@ -76,6 +82,7 @@ export const Observatory2: Landmark = {
 export const Publisher2: Landmark = {
   _id: 6,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Publisher',
   miniName: 'Publisher',
   description: 'Take 1 coin from each opponent for each ' + EstType.Shop + ' establishment they own (builder only).',
@@ -86,6 +93,7 @@ export const Publisher2: Landmark = {
 export const ShoppingMall2: Landmark = {
   _id: 7,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Shopping Mall',
   miniName: 'Shopping Mall',
   description: 'Your ' + EstType.Shop + ' establishments earn +1 coin when activated (all players).',
@@ -96,6 +104,7 @@ export const ShoppingMall2: Landmark = {
 export const TechStartup2: Landmark = {
   _id: 8,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Tech Startup',
   miniName: 'Tech Startup',
   description: 'If you roll 12, receive 8 coins from the bank (all players).',
@@ -106,6 +115,7 @@ export const TechStartup2: Landmark = {
 export const Airport2: Landmark = {
   _id: 9,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Airport',
   miniName: 'Airport',
   description: 'If you build nothing on your turn, receive 5 coins from the bank (all players).',
@@ -116,6 +126,7 @@ export const Airport2: Landmark = {
 export const AmusementPark2: Landmark = {
   _id: 10,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Amusement Park',
   miniName: 'Amuse. Park',
   description: 'If you roll doubles, take another turn after this one (all players).',
@@ -126,6 +137,7 @@ export const AmusementPark2: Landmark = {
 export const Charterhouse2: Landmark = {
   _id: 11,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Charterhouse',
   miniName: 'Charterhouse',
   description: 'If you roll 2 dice and receive no coins, receive 3 coins from the bank (all players).',
@@ -136,6 +148,7 @@ export const Charterhouse2: Landmark = {
 export const ExhibitHall2: Landmark = {
   _id: 12,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Exhibit Hall',
   miniName: 'Exhibit Hall',
   description: 'From each opponent who has more than 10 coins, take half, rounded down (builder only).',
@@ -146,6 +159,7 @@ export const ExhibitHall2: Landmark = {
 export const Forge2: Landmark = {
   _id: 13,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Forge',
   miniName: 'Forge',
   description: 'Your ' + EstType.Gear + ' establishments earn +1 coin when activated (all players).',
@@ -156,6 +170,7 @@ export const Forge2: Landmark = {
 export const Museum2: Landmark = {
   _id: 14,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Museum',
   miniName: 'Museum',
   description: 'Take 3 coins from each opponent for each landmark they own, excluding "City Hall" (builder only).',
@@ -166,6 +181,7 @@ export const Museum2: Landmark = {
 export const Park2: Landmark = {
   _id: 15,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Park',
   miniName: 'Park',
   description:
@@ -177,6 +193,7 @@ export const Park2: Landmark = {
 export const RadioTower2: Landmark = {
   _id: 16,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Radio Tower',
   miniName: 'Radio Tower',
   description: 'Take another turn after this one (builder only).',
@@ -187,6 +204,7 @@ export const RadioTower2: Landmark = {
 export const SodaBottlingPlant2: Landmark = {
   _id: 17,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Soda Bottling Plant',
   miniName: 'Soda Bt. Plant',
   description: 'Your ' + EstType.Cup + ' establishments earn +1 coin when activated (all players).',
@@ -197,6 +215,7 @@ export const SodaBottlingPlant2: Landmark = {
 export const Temple2: Landmark = {
   _id: 18,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Temple',
   miniName: 'Temple',
   description: 'If you roll doubles, take 2 coins from each opponent (all players).',
@@ -207,6 +226,7 @@ export const Temple2: Landmark = {
 export const TVStation2: Landmark = {
   _id: 19,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'TV Station',
   miniName: 'TV Station',
   description: 'Take 1 coin from each opponent for each ' + EstType.Cup + ' establishment they own (builder only).',
@@ -217,6 +237,7 @@ export const TVStation2: Landmark = {
 export const LaunchPad2: Landmark = {
   _id: 20,
   _ver: Version.MK2,
+  _exp: Expansion.Base,
   name: 'Launch Pad',
   miniName: 'Launch Pad',
   description: 'You win the game!',
@@ -257,11 +278,11 @@ export const _LANDMARKS2 = [
 export const _MK2_LANDMARKS: number[] = _LANDMARKS2.map((landmark) => landmark._id);
 
 /**
- * Landmarks a player starts with in Machi Koro 2.
+ * Additional landmarks a player starts with in Machi Koro 2.
  */
 export const _MK2_STARTING_LANDMARKS = [CityHall2._id];
 
 /**
  * Maximum number of unique landmarks in the supply for Machi Koro 2.
  */
-export const _SUPPY_LIMIT_LANDMARK = 5;
+export const _MK2_LANDMARK_SUPPLY_LIMIT = 5;

--- a/src/game/landmarks/metadata2.ts
+++ b/src/game/landmarks/metadata2.ts
@@ -2,9 +2,9 @@
 // Game metadata for Machi Koro 2 landmarks.
 //
 
+import { Expansion, Version } from '../types';
 import { EstType } from '../establishments/types';
 import { Landmark } from './types';
-import { Expansion, Version } from '../types';
 
 /**
  * Number of landmarks required to win the game.

--- a/src/game/landmarks/types.ts
+++ b/src/game/landmarks/types.ts
@@ -2,7 +2,7 @@
 // Types for landmarks.
 //
 
-import type { Version } from '../types';
+import type { Expansion, Version } from '../types';
 
 /**
  * Interface for landmark metadata.
@@ -16,6 +16,7 @@ import type { Version } from '../types';
  * coins earned, bonus coins earned, etc.
  * @prop {number} _id - Unique id used to enumerate landmarks.
  * @prop {Version} _ver - Used to distinguish Machi Koro 1 and 2 landmarks.
+ * @prop {Expansion} _exp - For Machi Koro 1, the expansion the landmark belongs to.
  */
 export interface Landmark {
   readonly name: string;
@@ -25,6 +26,7 @@ export interface Landmark {
   readonly coins: number | null;
   readonly _id: number;
   readonly _ver: Version;
+  readonly _exp: Expansion;
 }
 
 /**

--- a/src/game/machikoro.ts
+++ b/src/game/machikoro.ts
@@ -1023,8 +1023,8 @@ const endGame = (context: FnContext<MachikoroG>, winner: number): void => {
  * Set-up data for debug mode.
  */
 const debugSetupData: SetupData = {
-  version: Version.MK2,
-  expansions: [Expansion.Base],
+  version: Version.MK1,
+  expansions: [Expansion.Base, Expansion.Million],
   supplyVariant: SupplyVariant.Total,
   startCoins: 99,
   initialBuyRounds: 0,

--- a/src/game/machikoro.ts
+++ b/src/game/machikoro.ts
@@ -13,8 +13,8 @@ import * as Land from './landmarks';
 import * as Log from './log';
 import { EstColor, EstType, Establishment } from './establishments';
 import { Expansion, MachikoroG, SetupData, SupplyVariant, TurnState, Version } from './types';
-import { validateSetupData } from './utils';
 import { Landmark } from './landmarks';
+import { validateSetupData } from './utils';
 
 export const GAME_NAME = 'machikoro';
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -8,7 +8,8 @@ import type { LogEvent } from './log';
 
 /**
  * The `G` object containing all game state variables.
- * @prop {Expansion} expansion - the expansion of the game.
+ * @prop {Version} version - the version of the game.
+ * @prop {Expansion[]} expansions - the expansions used in the game.
  * @prop {SupplyVariant} supplyVariant - the supply variant of the game.
  * @prop {number} initialBuyRounds - the number of rounds of initial buying.
  * @prop {string[]} _turnOrder - the order of players in the game. Do not use
@@ -35,7 +36,8 @@ import type { LogEvent } from './log';
  * @prop {LogEvent[]|null} _logBuffer - buffer of log lines.
  */
 export interface MachikoroG {
-  readonly expansion: Expansion;
+  readonly version: Version;
+  readonly expansions: Expansion[];
   readonly supplyVariant: SupplyVariant;
   readonly initialBuyRounds: number;
   readonly _turnOrder: string[];
@@ -72,14 +74,16 @@ export interface Secret {
 
 /**
  * Data needed to setup a game.
- * @prop {Expansion} expansion - Expansion of the game.
+ * @prop {Version} version - Version of the game.
+ * @prop {Expansion[]} expansions - Expansions used in the game.
  * @prop {SupplyVariant} supplyVariant - Supply variant of the game.
  * @prop {number} startCoins - Number of coins each player starts with.
  * @prop {number} initialBuyRounds - Number of rounds of initial buying.
  * @prop {boolean} randomizeTurnOrder - True if the turn order should be randomized.
  */
 export interface SetupData {
-  expansion: Expansion;
+  version: Version;
+  expansions: Expansion[];
   supplyVariant: SupplyVariant;
   startCoins: number;
   initialBuyRounds: number;
@@ -111,7 +115,7 @@ export type TurnState = (typeof TurnState)[keyof typeof TurnState];
 export const Expansion = {
   Base: 'Base',
   Harbor: 'Harbor',
-  MK2: 'MK2',
+  Million: 'Millionaire Row',
 } as const;
 
 export type Expansion = (typeof Expansion)[keyof typeof Expansion];

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -115,7 +115,7 @@ export type TurnState = (typeof TurnState)[keyof typeof TurnState];
 export const Expansion = {
   Base: 'Base',
   Harbor: 'Harbor',
-  Million: 'Millionaire Row',
+  Million: "Millionaire's Row",
 } as const;
 
 export type Expansion = (typeof Expansion)[keyof typeof Expansion];

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -1,5 +1,5 @@
 //
-// Enums related to game configuration.
+// Private utility functions for game logic.
 //
 
 import { Expansion, SetupData, SupplyVariant, Version } from './types';

--- a/src/game/utils.ts
+++ b/src/game/utils.ts
@@ -2,25 +2,7 @@
 // Enums related to game configuration.
 //
 
-import { assertUnreachable } from 'common/typescript';
-
 import { Expansion, SetupData, SupplyVariant, Version } from './types';
-
-/**
- * Convert the expansion to the game version. "Base" and "Harbor" are both
- * version 1, while "MK2" is version 2.
- * @param exp
- * @returns
- */
-export const expToVer = (exp: Expansion): Version => {
-  if (exp === Expansion.Base || exp === Expansion.Harbor) {
-    return Version.MK1;
-  } else if (exp === Expansion.MK2) {
-    return Version.MK2;
-  } else {
-    return assertUnreachable(exp);
-  }
-};
 
 /**
  * Validate setup data. Returns a string if invalid.
@@ -30,9 +12,14 @@ export const expToVer = (exp: Expansion): Version => {
  */
 export const validateSetupData = (setupData: SetupData | undefined, numPlayers: number): string | undefined => {
   if (setupData) {
-    const { expansion, supplyVariant, initialBuyRounds, startCoins } = setupData;
-    if (!Object.values(Expansion).includes(expansion)) {
-      return `Unknown expansion: ${expansion}`;
+    const { version, expansions, supplyVariant, initialBuyRounds, startCoins } = setupData;
+    if (!Object.values(Version).includes(version)) {
+      return `Unknown version: ${version}`;
+    }
+    for (const expansion of expansions) {
+      if (!Object.values(Expansion).includes(expansion)) {
+        return `Unknown expansion: ${expansion}`;
+      }
     }
     if (!Object.values(SupplyVariant).includes(supplyVariant)) {
       return `Unknown supply variant: ${supplyVariant}`;
@@ -42,6 +29,14 @@ export const validateSetupData = (setupData: SetupData | undefined, numPlayers: 
     }
     if (!Number.isInteger(initialBuyRounds) || initialBuyRounds < 0) {
       return `Number of initial buying rounds, ${initialBuyRounds}, must be a non-negative integer`;
+    }
+    // Base expansion must always be included
+    if (!expansions.includes(Expansion.Base)) {
+      return `Base expansion must be included`;
+    }
+    // If Machi Koro 2, cannot contain additional expansions
+    if (version === Version.MK2 && expansions.length > 1) {
+      return `Machi Koro 2 cannot contain additional expansions`;
     }
   }
   if (!(Number.isInteger(numPlayers) && numPlayers >= 2 && numPlayers <= 5)) {

--- a/src/lobby/Lobby.tsx
+++ b/src/lobby/Lobby.tsx
@@ -13,7 +13,9 @@ import {
   SetupData,
   SupplyVariant,
   Version,
-  expToVer,
+  expansionName,
+  supplyVariantName,
+  versionName,
 } from 'game';
 
 import { FETCH_INTERVAL_MS, FETCH_TIMEOUT_MS } from 'common/config';
@@ -21,7 +23,7 @@ import { assertNonNull, assertUnreachable } from 'common/typescript';
 import { asyncCallWithTimeout, defaultErrorCatcher } from 'common/async';
 import { createMatchAPI, joinMatchAPI } from 'server/api';
 
-import { countPlayers, expansionName, hasDetails, supplyVariantName } from './utils';
+import { countPlayers, hasDetails } from './utils';
 import Authenticator from './Authenticator';
 import { MatchInfo } from './types';
 
@@ -47,14 +49,18 @@ interface LobbyProps {
  * @prop {boolean} connected - Whether the client is connected to the server.
  * @prop {Match[]|null} matches - List of current matches hosted on the server.
  * @prop {number} numPlayers - Number of players for the match.
- * @prop {Expansion} expansion - Expansion to play.
+ * @prop {Version} version - Version to play.
+ * @prop {boolean} useHarborExp - Whether to use the harbor expansion.
+ * @prop {boolean} useMillionExp - Whether to use the millionaire's row expansion.
  * @prop {SupplyVariant} supplyVariant - Supply variant to use.
  */
 interface LobbyState {
   connected: boolean;
   matches: LobbyAPI.Match[] | null; // null means no matches fetched
   numPlayers: number;
-  expansion: Expansion;
+  version: Version;
+  useHarborExp: boolean;
+  useMillionExp: boolean;
   supplyVariant: SupplyVariant;
 }
 
@@ -63,7 +69,8 @@ interface LobbyState {
  * @prop {Authenticator} authenticator - Manages local credential storage and retrieval.
  * @prop {RefObject} nameRef - Reference to the name input element.
  * @prop {RefObject} numPlayersRef - Reference to the number of players select element.
- * @prop {RefObject} expansionRef - Reference to the expansion select element.
+ * @prop {RefObject} harborExpRef - Reference to the harbor expansion checkbox element.
+ * @prop {RefObject} millionExpRef - Reference to the millionaire's row expansion checkbox element.
  * @prop {RefObject} supplyVariantRef - Reference to the supply variant select element.
  */
 export default class Lobby extends React.Component<LobbyProps, LobbyState> {
@@ -72,7 +79,9 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
 
   private nameRef: React.RefObject<HTMLInputElement>;
   private numPlayersRef: React.RefObject<HTMLSelectElement>;
-  private expansionRef: React.RefObject<HTMLSelectElement>;
+  private versionRef: React.RefObject<HTMLSelectElement>;
+  private harborExpRef: React.RefObject<HTMLInputElement>;
+  private millionExpRef: React.RefObject<HTMLInputElement>;
   private supplyVariantRef: React.RefObject<HTMLSelectElement>;
 
   constructor(props: LobbyProps) {
@@ -82,13 +91,17 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
       matches: null,
       // default values for new game
       numPlayers: 2,
-      expansion: Expansion.Base,
+      version: Version.MK1,
+      useHarborExp: false,
+      useMillionExp: false,
       supplyVariant: SupplyVariant.Hybrid,
     };
     this.authenticator = new Authenticator();
     this.nameRef = React.createRef();
     this.numPlayersRef = React.createRef();
-    this.expansionRef = React.createRef();
+    this.versionRef = React.createRef();
+    this.harborExpRef = React.createRef();
+    this.millionExpRef = React.createRef();
     this.supplyVariantRef = React.createRef();
   }
 
@@ -100,8 +113,27 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
     this.setState({ numPlayers: parseInt(e.target.value) });
   };
 
-  private setExpansion = (e: React.ChangeEvent<HTMLSelectElement>): void => {
-    this.setState({ expansion: e.target.value as Expansion });
+  private setVersion = (e: React.ChangeEvent<HTMLSelectElement>): void => {
+    const version = parseInt(e.target.value) as Version;
+    this.setState({ version: parseInt(e.target.value) as Version });
+    // disable expansions for Machi Koro 2
+    if (version === Version.MK2) {
+      this.setState({ useHarborExp: false, useMillionExp: false });
+      if (this.harborExpRef.current) {
+        this.harborExpRef.current.checked = false;
+      }
+      if (this.millionExpRef.current) {
+        this.millionExpRef.current.checked = false;
+      }
+    }
+  };
+
+  private toggleHarborExp = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    this.setState({ useHarborExp: e.target.checked });
+  };
+
+  private toggleMillionExp = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    this.setState({ useMillionExp: e.target.checked });
   };
 
   private setSupplyVariant = (e: React.ChangeEvent<HTMLSelectElement>): void => {
@@ -144,7 +176,7 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
    */
   private createMatch = async (): Promise<string> => {
     const { name, lobbyClient } = this.props;
-    const { connected, numPlayers, expansion, supplyVariant } = this.state;
+    const { connected, numPlayers, version, useHarborExp, useMillionExp, supplyVariant } = this.state;
 
     if (!connected) {
       throw new Error('Cannot create match: Not connected to server.');
@@ -153,7 +185,6 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
     // initialize setup data
     let startCoins;
     let initialBuyRounds;
-    const version = expToVer(expansion);
     if (version === Version.MK1) {
       startCoins = MK1_STARTING_COINS;
       initialBuyRounds = 0;
@@ -164,8 +195,17 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
       return assertUnreachable(version);
     }
 
+    const expansions: Expansion[] = [Expansion.Base];
+    if (useHarborExp) {
+      expansions.push(Expansion.Harbor);
+    }
+    if (useMillionExp) {
+      expansions.push(Expansion.Million);
+    }
+
     const setupData: SetupData = {
-      expansion,
+      version,
+      expansions,
       supplyVariant,
       startCoins,
       initialBuyRounds,
@@ -271,7 +311,7 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
 
   componentDidMount() {
     const { name } = this.props;
-    const { numPlayers, expansion, supplyVariant } = this.state;
+    const { numPlayers, version, useHarborExp, useMillionExp, supplyVariant } = this.state;
 
     this.props.clearErrorMessage();
 
@@ -282,8 +322,14 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
     if (this.numPlayersRef.current) {
       this.numPlayersRef.current.value = numPlayers.toString();
     }
-    if (this.expansionRef.current) {
-      this.expansionRef.current.value = expansion.toString();
+    if (this.versionRef.current) {
+      this.versionRef.current.value = version.toString();
+    }
+    if (this.harborExpRef.current) {
+      this.harborExpRef.current.checked = useHarborExp;
+    }
+    if (this.millionExpRef.current) {
+      this.millionExpRef.current.checked = useMillionExp;
     }
     if (this.supplyVariantRef.current) {
       this.supplyVariantRef.current.value = supplyVariant.toString();
@@ -330,48 +376,71 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
    */
   private renderCreateMatch = (): JSX.Element => {
     // prettier-ignore
-    const numPlayersOptions = [
-      <option key='0' value='2'>2 Players</option>,
-      <option key='1' value='3'>3 Players</option>,
-      <option key='2' value='4'>4 Players</option>,
-      <option key='3' value='5'>5 Players</option>,
-    ];
+    const versionOptions = 
+      <select ref={this.versionRef} onChange={this.setVersion}>
+        <option key='0' value={Version.MK1.toString()}>{versionName(Version.MK1)}</option>
+        <option key='1' value={Version.MK2.toString()}>{versionName(Version.MK2)}</option>
+      </select>
 
     // prettier-ignore
-    const expansionOptions = [
-      <option key='0' value={Expansion.Base}>{expansionName(Expansion.Base)}</option>,
-      <option key='1' value={Expansion.Harbor}>{expansionName(Expansion.Harbor)}</option>,
-      <option key='2' value={Expansion.MK2}>{expansionName(Expansion.MK2)}</option>
-    ];
+    const numPlayersOptions = 
+      <select ref={this.numPlayersRef} onChange={this.setNumPlayers}>
+        <option key='0' value='2'>2 Players</option>,
+        <option key='1' value='3'>3 Players</option>,
+        <option key='2' value='4'>4 Players</option>,
+        <option key='3' value='5'>5 Players</option>,
+      </select>
+
+    // expansions cannot be toggled for Machi Koro 2
+    const expOptsDisabled = this.state.version === Version.MK2;
+    const expansionOptions = (
+      <div style={{ textAlign: 'left' }}>
+        <input
+          key='0'
+          type='checkbox'
+          ref={this.harborExpRef}
+          onChange={this.toggleHarborExp}
+          disabled={expOptsDisabled}
+        />
+        Harbor
+        <br />
+        <input
+          key='1'
+          type='checkbox'
+          ref={this.millionExpRef}
+          onChange={this.toggleMillionExp}
+          disabled={expOptsDisabled}
+        />
+        {"Millionaire's Row"}
+      </div>
+    );
 
     // prettier-ignore
-    const supplyVariantOptions = [
-      <option key='0' value={SupplyVariant.Hybrid}>{supplyVariantName(SupplyVariant.Hybrid)}</option>,
-      <option key='1' value={SupplyVariant.Variable}>{supplyVariantName(SupplyVariant.Variable)}</option>,
-      <option key='2' value={SupplyVariant.Total}>{supplyVariantName(SupplyVariant.Total)}</option>
-    ];
+    const supplyVariantOptions =
+      <select ref={this.supplyVariantRef} onChange={this.setSupplyVariant}>
+        <option key='0' value={SupplyVariant.Hybrid}>{supplyVariantName(SupplyVariant.Hybrid)}</option>,
+        <option key='1' value={SupplyVariant.Variable}>{supplyVariantName(SupplyVariant.Variable)}</option>,
+        <option key='2' value={SupplyVariant.Total}>{supplyVariantName(SupplyVariant.Total)}</option>
+      </select>
 
     return (
       <div className='padded_div'>
         <span className='subtitle'>Create Room</span>
         <br />
-        <select ref={this.numPlayersRef} onChange={this.setNumPlayers}>
-          {numPlayersOptions}
-        </select>
-        <select ref={this.expansionRef} onChange={this.setExpansion}>
+        <div className='div-inline-flex'>
+          {versionOptions}
           {expansionOptions}
-        </select>
-        <select ref={this.supplyVariantRef} onChange={this.setSupplyVariant}>
           {supplyVariantOptions}
-        </select>
-        <button
-          className='button'
-          onClick={() => {
-            this.createAndJoinMatch().catch(defaultErrorCatcher);
-          }}
-        >
-          Create Room
-        </button>
+          {numPlayersOptions}
+          <button
+            className='button'
+            onClick={() => {
+              this.createAndJoinMatch().catch(defaultErrorCatcher);
+            }}
+          >
+            Create Room
+          </button>
+        </div>
       </div>
     );
   };
@@ -455,7 +524,7 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
               </div>
             </div>
             <div className='lobby-div-col lobby-div-col-width'>
-              <div className='lobby-div-row'>{expansionName(setupData.expansion)}</div>
+              <div className='lobby-div-row'>{expansionName(setupData.expansions[0])}</div>
               <div className='lobby-div-row'>{supplyVariantName(setupData.supplyVariant)}</div>
             </div>
             <div className='lobby-div-col lobby-div-col-width'>

--- a/src/lobby/Lobby.tsx
+++ b/src/lobby/Lobby.tsx
@@ -13,7 +13,7 @@ import {
   SetupData,
   SupplyVariant,
   Version,
-  expansionName,
+  displayName,
   supplyVariantName,
   versionName,
 } from 'game';
@@ -116,9 +116,10 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
   private setVersion = (e: React.ChangeEvent<HTMLSelectElement>): void => {
     const version = parseInt(e.target.value) as Version;
     this.setState({ version: parseInt(e.target.value) as Version });
-    // disable expansions for Machi Koro 2
     if (version === Version.MK2) {
+      // disable expansions for Machi Koro 2
       this.setState({ useHarborExp: false, useMillionExp: false });
+      // uncheck the boxes
       if (this.harborExpRef.current) {
         this.harborExpRef.current.checked = false;
       }
@@ -376,13 +377,6 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
    */
   private renderCreateMatch = (): JSX.Element => {
     // prettier-ignore
-    const versionOptions = 
-      <select ref={this.versionRef} onChange={this.setVersion}>
-        <option key='0' value={Version.MK1.toString()}>{versionName(Version.MK1)}</option>
-        <option key='1' value={Version.MK2.toString()}>{versionName(Version.MK2)}</option>
-      </select>
-
-    // prettier-ignore
     const numPlayersOptions = 
       <select ref={this.numPlayersRef} onChange={this.setNumPlayers}>
         <option key='0' value='2'>2 Players</option>,
@@ -391,8 +385,15 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
         <option key='3' value='5'>5 Players</option>,
       </select>
 
+    // prettier-ignore
+    const versionOptions = 
+      <select ref={this.versionRef} onChange={this.setVersion}>
+        <option key='0' value={Version.MK1.toString()}>{versionName(Version.MK1)}</option>
+        <option key='1' value={Version.MK2.toString()}>{versionName(Version.MK2)}</option>
+      </select>
+
     // expansions cannot be toggled for Machi Koro 2
-    const expOptsDisabled = this.state.version === Version.MK2;
+    const expansionOptionsDisabled = this.state.version === Version.MK2;
     const expansionOptions = (
       <div style={{ textAlign: 'left' }}>
         <input
@@ -400,7 +401,7 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
           type='checkbox'
           ref={this.harborExpRef}
           onChange={this.toggleHarborExp}
-          disabled={expOptsDisabled}
+          disabled={expansionOptionsDisabled}
         />
         Harbor
         <br />
@@ -409,7 +410,7 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
           type='checkbox'
           ref={this.millionExpRef}
           onChange={this.toggleMillionExp}
-          disabled={expOptsDisabled}
+          disabled={expansionOptionsDisabled}
         />
         {"Millionaire's Row"}
       </div>
@@ -524,7 +525,7 @@ export default class Lobby extends React.Component<LobbyProps, LobbyState> {
               </div>
             </div>
             <div className='lobby-div-col lobby-div-col-width'>
-              <div className='lobby-div-row'>{expansionName(setupData.expansions[0])}</div>
+              <div className='lobby-div-row'>{displayName(setupData.version, setupData.expansions)}</div>
               <div className='lobby-div-row'>{supplyVariantName(setupData.supplyVariant)}</div>
             </div>
             <div className='lobby-div-col lobby-div-col-width'>

--- a/src/lobby/Room.tsx
+++ b/src/lobby/Room.tsx
@@ -5,13 +5,13 @@ import { LobbyClient } from 'boardgame.io/client';
 import React from 'react';
 import { Server } from 'boardgame.io';
 
-import { Expansion, GAME_NAME, SetupData, SupplyVariant } from 'game';
+import { Expansion, GAME_NAME, SetupData, SupplyVariant, Version, displayName, supplyVariantName } from 'game';
 import { FETCH_INTERVAL_MS, FETCH_TIMEOUT_MS } from 'common/config';
 import { asyncCallWithTimeout, defaultErrorCatcher } from 'common/async';
 
-import { countPlayers, expansionName, supplyVariantName } from './utils';
 import Authenticator from './Authenticator';
 import { MatchInfo } from './types';
+import { countPlayers } from './utils';
 
 /**
  * @prop {string} name - Name of the player.
@@ -36,13 +36,15 @@ interface RoomProps {
 /**
  * @prop {string} name - Name of the player.
  * @prop {PlayerMetadata[]} players - List of metadata for players in the room.
- * @prop {Expansion|null} expansion - Expansion to play. This is initially null, but is fetched.
+ * @prop {Version|null} version - Version to play. This is initially null, but is fetched.
+ * @prop {Expansion[]|null} expansions - Expansions to play. This is initially null, but is fetched.
  * @prop {SupplyVariant|null} supplyVariant - Supply variant to use. This is initially null, but is fetched.
  */
 interface RoomState {
   connected: boolean;
   players: Server.PlayerMetadata[];
-  expansion: Expansion | null;
+  version: Version | null;
+  expansions: Expansion[] | null;
   supplyVariant: SupplyVariant | null;
 }
 
@@ -59,7 +61,8 @@ export default class Room extends React.Component<RoomProps, RoomState> {
     this.state = {
       connected: false,
       players: [],
-      expansion: null,
+      version: null,
+      expansions: null,
       supplyVariant: null,
     };
     this.authenticator = new Authenticator();
@@ -97,8 +100,8 @@ export default class Room extends React.Component<RoomProps, RoomState> {
       this.setState({ connected: true });
     }
 
-    const { expansion, supplyVariant } = match.setupData as SetupData;
-    this.setState({ players: match.players, expansion, supplyVariant });
+    const { version, expansions, supplyVariant } = match.setupData as SetupData;
+    this.setState({ players: match.players, version, expansions, supplyVariant });
   };
 
   /**
@@ -191,7 +194,7 @@ export default class Room extends React.Component<RoomProps, RoomState> {
 
   render() {
     const { matchInfo } = this.props;
-    const { expansion, supplyVariant } = this.state;
+    const { version, expansions, supplyVariant } = this.state;
 
     return (
       <div>
@@ -202,7 +205,7 @@ export default class Room extends React.Component<RoomProps, RoomState> {
               <b>Room ID:</b> {matchInfo.matchID}
             </div>
             <div className='mm-div-cell'>
-              <b>{expansionName(expansion)}</b>
+              <b>{displayName(version, expansions)}</b>
             </div>
             <div className='mm-div-cell'>
               <b>{supplyVariantName(supplyVariant)}</b>

--- a/src/lobby/utils.ts
+++ b/src/lobby/utils.ts
@@ -1,7 +1,5 @@
 import { Server } from 'boardgame.io';
 
-import { Expansion, SupplyVariant } from 'game';
-
 /**
  * Currently, the most reliable way to check if a seat is occupied is to check
  * if the `PlayerMetadata` object contains the field 'name'. If yes, then it is
@@ -20,40 +18,6 @@ export function seatIsOccupied(player: Server.PlayerMetadata): boolean {
  */
 export function countPlayers(players: Server.PlayerMetadata[]): number {
   return players.filter(seatIsOccupied).length;
-}
-
-/**
- * @param expansion
- * @returns Display name for expansion.
- */
-export function expansionName(expansion: Expansion | null): string {
-  switch (expansion) {
-    case Expansion.Base:
-      return 'Base Game';
-    case Expansion.Harbor:
-      return 'Harbor Expansion';
-    case Expansion.MK2:
-      return 'Machi Koro 2';
-    default:
-      return '??? Expansion';
-  }
-}
-
-/**
- * @param supplyVariant
- * @returns Display name for supply variant.
- */
-export function supplyVariantName(supplyVariant: SupplyVariant | null): string {
-  switch (supplyVariant) {
-    case SupplyVariant.Hybrid:
-      return 'Hybrid Supply';
-    case SupplyVariant.Variable:
-      return 'Variable Supply';
-    case SupplyVariant.Total:
-      return 'Total Supply';
-    default:
-      return '??? Supply Variant';
-  }
 }
 
 export interface IDetails {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -45,6 +45,10 @@
   display: flex;
 }
 
+.div-inline-flex {
+  display: inline-flex;
+}
+
 /* 
    FONTS
    (Icons from Material Symbols are loaded as a font)


### PR DESCRIPTION
Added UI elements for toggling expansions. In particular, added the "Millionaire's Row" expansion, but this currently does not do anything.

A bunch of internal game stuff had to be changed, because Machi Koro 2 used to be considered an expansion.

- The `Expansion` enum no longer includes `MK2`, but now includes `Million`.
- The `Expansion` enum has been added as a property to the `Establishment` and `Landmark` objects, so it is easier to track which cards come from which expansion.
- A `G.version: Version` property has been added. Similarly, the `G.expansion: Expansion` property has been replaced with an array, `G.expansions: Expansion[]`.
- The `expToVer()` function has been removed as it is no longer needed.
- Added a `game/display` module which has a bunch of expansion/version to human-readable string conversion functions all in one place.

<img width="869" alt="Screen Shot 2023-10-06 at 00 17 23" src="https://github.com/kevinddchen/machikoro/assets/79341521/c5dc10b0-6e97-4f43-b3b3-5cb14529dccf">

Work towards #113 .
