### PR TITLE
Implement Millionaire's Row establishments: Part I

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The app is online and free to play at <a href="https://playmachikoro.herokuapp.c
 ### Implementation details
 
 Because this game was implemented to be automatic as much as possible, there are certain uncommon plays that are not possible.
-  
+
 - `Loan Office` always activates before `Forest` and `Flower Shop`.
 - `Demolition Company` always activates before `Corn Field`.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ The app is online and free to play at <a href="https://playmachikoro.herokuapp.c
 - **Variable**: 10 establishments are available for purchase from the supply. This is the official supply variant of the expansions.
 - **Hybrid**: 5 establishments with rolls 1-6, 5 establishments with rolls 7+, and 2 major establishments are available for purchase from the supply. This is the official supply variant of Machi Koro 2.
 
+### Implementation details
+
+Because this game was implemented to be automatic as much as possible, there are certain uncommon plays that are not possible.
+  
+- `Loan Office` always activates before `Forest` and `Flower Shop`.
+- `Demolition Company` always activates before `Corn Field`.
+
 ## Development
 
 First, install [Node.js](https://nodejs.org/en/).

--- a/src/game/establishments/metadata.ts
+++ b/src/game/establishments/metadata.ts
@@ -402,7 +402,6 @@ export const FoodWarehouse: Establishment = {
   _initial: 6,
 };
 
-// TODO: implement this
 export const MembersOnlyClub: Establishment = {
   _id: 28,
   version: Version.MK1,

--- a/src/game/establishments/metadata.ts
+++ b/src/game/establishments/metadata.ts
@@ -216,7 +216,6 @@ export const PizzaJoint: Establishment = {
   _initial: 6,
 };
 
-// TODO: implement this
 export const Vineyard: Establishment = {
   _id: 15,
   version: Version.MK1,
@@ -361,7 +360,6 @@ export const AppleOrchard: Establishment = {
   _initial: 6,
 };
 
-// TODO: implement this
 export const SodaBottlingPlant: Establishment = {
   _id: 25,
   version: Version.MK1,

--- a/src/game/establishments/metadata.ts
+++ b/src/game/establishments/metadata.ts
@@ -89,7 +89,6 @@ export const Cafe: Establishment = {
   _initial: 6,
 };
 
-// TODO: implement this
 export const CornField: Establishment = {
   _id: 6,
   version: Version.MK1,

--- a/src/game/establishments/metadata.ts
+++ b/src/game/establishments/metadata.ts
@@ -174,7 +174,6 @@ export const Forest: Establishment = {
   _initial: 6,
 };
 
-// TODO: implement this
 export const LoanOffice: Establishment = {
   _id: 12,
   version: Version.MK1,

--- a/src/game/establishments/metadata.ts
+++ b/src/game/establishments/metadata.ts
@@ -146,7 +146,6 @@ export const DemolitionCompany: Establishment = {
   _initial: 6,
 };
 
-// TODO: implement this
 export const FrenchRestaurant: Establishment = {
   _id: 10,
   version: Version.MK1,

--- a/src/game/establishments/metadata.ts
+++ b/src/game/establishments/metadata.ts
@@ -47,7 +47,6 @@ export const Ranch: Establishment = {
   _initial: 6,
 };
 
-// TODO: implement this
 export const GeneralStore: Establishment = {
   _id: 3,
   version: Version.MK1,

--- a/src/game/landmarks/main.ts
+++ b/src/game/landmarks/main.ts
@@ -120,10 +120,8 @@ export const getAllOwned = (G: MachikoroG, player: number): Landmark[] => {
  * landmarks owned by the player other than "City Hall".
  */
 export const countBuilt = (G: MachikoroG, player: number): number => {
-  if (G.version !== Version.MK2) {
-    throw new Error('`countBuilt()` is only implemented for Machi Koro 2.');
-  }
-  return getAllOwned(G, player).filter((land) => !isEqual(land, Meta2.CityHall2)).length;
+  return getAllOwned(G, player).filter((land) => !isEqual(land, Meta.CityHall) && !isEqual(land, Meta2.CityHall2))
+    .length;
 };
 
 /**

--- a/src/game/log/parsers.ts
+++ b/src/game/log/parsers.ts
@@ -184,7 +184,13 @@ export const logEarn = (G: MachikoroG, player: number, amount: number, name: str
  */
 const parseEarn = (logEvent: Earn, names: string[]): string => {
   const { player, amount, name } = logEvent;
-  return `\t${names[player]} earned ${amount} coins (${name})`;
+  let text: string;
+  if (amount > 0) {
+    text = `\t${names[player]} earned ${amount} coins (${name})`;
+  } else {
+    text = `\t${names[player]} paid the bank ${-amount} coins (${name})`;
+  }
+  return text;
 };
 
 // ----------------------------------------------------------------------------

--- a/src/game/machikoro.ts
+++ b/src/game/machikoro.ts
@@ -757,6 +757,8 @@ const activateEsts = (context: FnContext<MachikoroG>): void => {
       multiplier = Est.countTypeOwned(G, currentPlayer, EstType.Cup);
     } else if (Est.isEqual(est, Est.Winery2)) {
       multiplier = Est.countTypeOwned(G, currentPlayer, EstType.Fruit);
+    } else if (Est.isEqual(est, Est.GeneralStore)) {
+      multiplier = Land.countBuilt(G, currentPlayer) < 2 ? 1 : 0;
     } else {
       multiplier = 1;
     }

--- a/src/game/machikoro.ts
+++ b/src/game/machikoro.ts
@@ -715,7 +715,16 @@ const activateEsts = (context: FnContext<MachikoroG>): void => {
         earnings += Land.Forge2.coins;
       }
 
-      const amount = earnings * count;
+      // by default a blue establishment earns `multiplier * earnings = 1 * earnings`
+      // but there are special cases where `multiplier` is not 1.
+      let multiplier: number;
+      if (Est.isEqual(est, Est.CornField)) {
+        multiplier = Land.countBuilt(G, player) < 2 ? 1 : 0;
+      } else {
+        multiplier = 1;
+      }
+
+      const amount = earnings * multiplier * count;
       earn(G, ctx, player, amount, est.name);
     }
   }
@@ -741,8 +750,8 @@ const activateEsts = (context: FnContext<MachikoroG>): void => {
     }
 
     // by default a green establishment earns `multiplier * earnings = 1 * earnings`
-    // but there are many special cases where `multiplier` is not 1.
-    let multiplier;
+    // but there are special cases where `multiplier` is not 1.
+    let multiplier: number;
     if (Est.isEqual(est, Est.CheeseFactory)) {
       multiplier = Est.countTypeOwned(G, currentPlayer, EstType.Animal);
     } else if (Est.isEqual(est, Est.FurnitureFactory) || Est.isEqual(est, Est.FurnitureFactory2)) {

--- a/src/game/machikoro.ts
+++ b/src/game/machikoro.ts
@@ -655,8 +655,14 @@ const activateEsts = (context: FnContext<MachikoroG>): void => {
         continue;
       }
 
-      // all red establishments take `est.earn` coins from the player
-      let earnings = est.earn;
+      // Member's Only Club earnings are all coins from the opponent
+      // all other red establishments get `est.earn` coins from the bank
+      let earnings: number;
+      if (Est.isEqual(est, Est.MembersOnlyClub)) {
+        earnings = getCoins(G, currentPlayer);
+      } else {
+        earnings = est.earn;
+      }
 
       // +1 coin to Cup type if opponent owns Shopping Mall
       if (est.type === EstType.Cup && Land.owns(G, opponent, Land.ShoppingMall)) {
@@ -676,6 +682,8 @@ const activateEsts = (context: FnContext<MachikoroG>): void => {
         multiplier = Land.owns(G, opponent, Land.Harbor) ? 1 : 0;
       } else if (Est.isEqual(est, Est.FrenchRestaurant)) {
         multiplier = Land.countBuilt(G, currentPlayer) >= 2 ? 1 : 0;
+      } else if (Est.isEqual(est, Est.MembersOnlyClub)) {
+        multiplier = Land.countBuilt(G, currentPlayer) >= 3 ? 1 : 0;
       } else {
         multiplier = 1;
       }

--- a/src/game/machikoro.ts
+++ b/src/game/machikoro.ts
@@ -785,6 +785,11 @@ const activateEsts = (context: FnContext<MachikoroG>): void => {
       multiplier = Est.countTypeOwned(G, currentPlayer, EstType.Fruit);
     } else if (Est.isEqual(est, Est.GeneralStore)) {
       multiplier = Land.countBuilt(G, currentPlayer) < 2 ? 1 : 0;
+    } else if (Est.isEqual(est, Est.SodaBottlingPlant)) {
+      multiplier = 0;
+      for (const player of getNextPlayers(ctx)) {
+        multiplier += Est.countTypeOwned(G, player, EstType.Cup);
+      }
     } else {
       multiplier = 1;
     }
@@ -1055,7 +1060,7 @@ const debugSetupData: SetupData = {
   version: Version.MK1,
   expansions: [Expansion.Base, Expansion.Harbor, Expansion.Million],
   supplyVariant: SupplyVariant.Total,
-  startCoins: 3,
+  startCoins: 99,
   initialBuyRounds: 0,
   randomizeTurnOrder: false,
 };


### PR DESCRIPTION
This PR implements 7/14 of the establishments included in the Millionaire's Row expansion. These ones are the more straight-forward ones:
- General Store
- Corn Field
- French Restaurant
- Loan Office
- Vineyard
- Soda Bottling Plant
- Member's Only Club

Work towards #113 .