### PR TITLE
Split hybrid supply rows into their respective decks

### DIFF
--- a/src/board/StackTable.tsx
+++ b/src/board/StackTable.tsx
@@ -37,7 +37,7 @@ export default class StackTable {
   render(): JSX.Element {
     this.pushRow();
     return (
-      <table className='stack-table'>
+      <table>
         <tbody>{this.tbody}</tbody>
       </table>
     );

--- a/src/board/Supply.tsx
+++ b/src/board/Supply.tsx
@@ -82,9 +82,10 @@ export default class Supply extends React.Component<SupplyProps, object> {
   private renderEstTable = (): JSX.Element[] => {
     const { G, ctx, moves, isActive } = this.props;
 
-    // use one table for each deck
+    // use one stack table for each deck, so that the rows corresponding to
+    // different decks will not combine into each other
     const numTables = Est.getNumDecks(G.supplyVariant, G.version);
-    const tables = Array.from({length: numTables}, () => new StackTable(5));
+    const tables = Array.from({ length: numTables }, () => new StackTable(5));
 
     const ests = Est.getAllInUse(G.version, G.expansions);
     for (let i = 0; i < ests.length; i++) {

--- a/src/board/Supply.tsx
+++ b/src/board/Supply.tsx
@@ -79,10 +79,12 @@ export default class Supply extends React.Component<SupplyProps, object> {
     return table.render();
   };
 
-  private renderEstTable = (): JSX.Element => {
+  private renderEstTable = (): JSX.Element[] => {
     const { G, ctx, moves, isActive } = this.props;
 
-    const table = new StackTable(5);
+    // use one table for each deck
+    const numTables = Est.numDecks(G.supplyVariant, G.version);
+    const tables = Array.from({length: numTables}, () => new StackTable(5));
 
     const ests = Est.getAllInUse(G.version, G.expansions);
     for (let i = 0; i < ests.length; i++) {
@@ -109,7 +111,10 @@ export default class Supply extends React.Component<SupplyProps, object> {
       const estRollBoxes = formatRollBoxes(est.rolls, 'est_roll_box');
       const estDescription = parseMaterialSymbols(est.description);
 
-      table.push(
+      // get the table index to push to
+      const idx = Est.deckIndex(G.supplyVariant, G.version, est);
+
+      tables[idx].push(
         <td
           key={i}
           className={classNames('est_td', estColor, { inactive: available === 0 }, { clickable: canBuyEst })}
@@ -129,14 +134,14 @@ export default class Supply extends React.Component<SupplyProps, object> {
       );
     }
 
-    return table.render();
+    return tables.map((table, i) => <div key={i}>{table.render()}</div>);
   };
 
   render() {
     return (
       <div>
         <div>{this.renderLandTable()}</div>
-        <div>{this.renderEstTable()}</div>
+        {this.renderEstTable()}
       </div>
     );
   }

--- a/src/board/Supply.tsx
+++ b/src/board/Supply.tsx
@@ -83,7 +83,7 @@ export default class Supply extends React.Component<SupplyProps, object> {
     const { G, ctx, moves, isActive } = this.props;
 
     // use one table for each deck
-    const numTables = Est.numDecks(G.supplyVariant, G.version);
+    const numTables = Est.getNumDecks(G.supplyVariant, G.version);
     const tables = Array.from({length: numTables}, () => new StackTable(5));
 
     const ests = Est.getAllInUse(G.version, G.expansions);
@@ -112,7 +112,7 @@ export default class Supply extends React.Component<SupplyProps, object> {
       const estDescription = parseMaterialSymbols(est.description);
 
       // get the table index to push to
-      const idx = Est.deckIndex(G.supplyVariant, G.version, est);
+      const idx = Est.getDeckIndex(G.supplyVariant, G.version, est);
 
       tables[idx].push(
         <td

--- a/src/game/establishments/main.ts
+++ b/src/game/establishments/main.ts
@@ -365,7 +365,8 @@ export const initialize = (
   const inUse = getAllInUse(version, expansions);
   for (const est of inUse) {
     // if `est._initial` is null, use the number of players
-    estData._remainingCount[est._id] = est._initial ?? numPlayers;
+    // estData._remainingCount[est._id] = est._initial ?? numPlayers;
+    estData._remainingCount[est._id] = 1;
   }
 
   // give each player their starting establishments
@@ -384,41 +385,10 @@ export const initialize = (
   }
 
   // prepare decks
-  let estDecks: Establishment[][];
-  if (supplyVariant === SupplyVariant.Total || supplyVariant === SupplyVariant.Variable) {
-    // put all cards into one deck
-    estDecks = [[]];
-    for (const est of inUse) {
-      estDecks[0].push(...Array.from({ length: estData._remainingCount[est._id] }, () => est));
-    }
-  } else if (supplyVariant === SupplyVariant.Hybrid) {
-    if (version === Version.MK1) {
-      // put all cards into three decks: lower, upper, and major (purple)
-      estDecks = [[], [], []];
-      for (const est of inUse) {
-        if (isMajor(est)) {
-          estDecks[2].push(...Array.from({ length: estData._remainingCount[est._id] }, () => est));
-        } else if (isLower(est)) {
-          estDecks[0].push(...Array.from({ length: estData._remainingCount[est._id] }, () => est));
-        } else {
-          estDecks[1].push(...Array.from({ length: estData._remainingCount[est._id] }, () => est));
-        }
-      }
-    } else if (version === Version.MK2) {
-      // put all cards into two decks: lower and upper
-      estDecks = [[], []];
-      for (const est of inUse) {
-        if (isLower(est)) {
-          estDecks[0].push(...Array.from({ length: estData._remainingCount[est._id] }, () => est));
-        } else {
-          estDecks[1].push(...Array.from({ length: estData._remainingCount[est._id] }, () => est));
-        }
-      }
-    } else {
-      return assertUnreachable(version);
-    }
-  } else {
-    return assertUnreachable(supplyVariant);
+  const estDecks: Establishment[][] = Array.from({ length: numDecks(supplyVariant, version) }, () => []);
+  for (const est of inUse) {
+    const idx = deckIndex(supplyVariant, version, est);
+    estDecks[idx].push(...Array.from({ length: estData._remainingCount[est._id] }, () => est));
   }
 
   return { estData, estDecks };
@@ -446,4 +416,57 @@ export const isUpper = (est: Establishment): boolean => {
  */
 export const isMajor = (est: Establishment): boolean => {
   return est.color === EstColor.Purple;
+};
+
+/**
+ * @param supplyVariant
+ * @param version
+ * @returns The number of decks to use for the game setup.
+ */
+export const numDecks = (supplyVariant: SupplyVariant, version: Version): number => {
+  if (supplyVariant === SupplyVariant.Total || supplyVariant === SupplyVariant.Variable) {
+    return 1; // put all cards into one deck
+  } else if (supplyVariant === SupplyVariant.Hybrid) {
+    if (version === Version.MK1) {
+      return 3; // put all cards into three decks: lower, upper, and major (purple)
+    } else if (version === Version.MK2) {
+      return 2; // put all cards into two decks: lower and upper
+    } else {
+      return assertUnreachable(version);
+    }
+  } else {
+    return assertUnreachable(supplyVariant);
+  }
+};
+
+/**
+ * @param supplyVariant
+ * @param version
+ * @param est
+ * @returns The deck index that the establishment should be placed in.
+ */
+export const deckIndex = (supplyVariant: SupplyVariant, version: Version, est: Establishment): number => {
+  if (supplyVariant === SupplyVariant.Total || supplyVariant === SupplyVariant.Variable) {
+    return 0;
+  } else if (supplyVariant === SupplyVariant.Hybrid) {
+    if (version === Version.MK1) {
+      if (isMajor(est)) {
+        return 2;
+      } else if (isLower(est)) {
+        return 0;
+      } else {
+        return 1;
+      }
+    } else if (version === Version.MK2) {
+      if (isLower(est)) {
+        return 0;
+      } else {
+        return 1;
+      }
+    } else {
+      return assertUnreachable(version);
+    }
+  } else {
+    return assertUnreachable(supplyVariant);
+  }
 };

--- a/src/game/establishments/main.ts
+++ b/src/game/establishments/main.ts
@@ -365,8 +365,7 @@ export const initialize = (
   const inUse = getAllInUse(version, expansions);
   for (const est of inUse) {
     // if `est._initial` is null, use the number of players
-    // estData._remainingCount[est._id] = est._initial ?? numPlayers;
-    estData._remainingCount[est._id] = 1;
+    estData._remainingCount[est._id] = est._initial ?? numPlayers;
   }
 
   // give each player their starting establishments
@@ -385,9 +384,10 @@ export const initialize = (
   }
 
   // prepare decks
-  const estDecks: Establishment[][] = Array.from({ length: numDecks(supplyVariant, version) }, () => []);
+  const numDecks = getNumDecks(supplyVariant, version);
+  const estDecks: Establishment[][] = Array.from({ length: numDecks }, () => []);
   for (const est of inUse) {
-    const idx = deckIndex(supplyVariant, version, est);
+    const idx = getDeckIndex(supplyVariant, version, est);
     estDecks[idx].push(...Array.from({ length: estData._remainingCount[est._id] }, () => est));
   }
 
@@ -423,7 +423,7 @@ export const isMajor = (est: Establishment): boolean => {
  * @param version
  * @returns The number of decks to use for the game setup.
  */
-export const numDecks = (supplyVariant: SupplyVariant, version: Version): number => {
+export const getNumDecks = (supplyVariant: SupplyVariant, version: Version): number => {
   if (supplyVariant === SupplyVariant.Total || supplyVariant === SupplyVariant.Variable) {
     return 1; // put all cards into one deck
   } else if (supplyVariant === SupplyVariant.Hybrid) {
@@ -445,7 +445,7 @@ export const numDecks = (supplyVariant: SupplyVariant, version: Version): number
  * @param est
  * @returns The deck index that the establishment should be placed in.
  */
-export const deckIndex = (supplyVariant: SupplyVariant, version: Version, est: Establishment): number => {
+export const getDeckIndex = (supplyVariant: SupplyVariant, version: Version, est: Establishment): number => {
   if (supplyVariant === SupplyVariant.Total || supplyVariant === SupplyVariant.Variable) {
     return 0;
   } else if (supplyVariant === SupplyVariant.Hybrid) {

--- a/src/game/machikoro.ts
+++ b/src/game/machikoro.ts
@@ -1543,7 +1543,7 @@ const activatePark = (G: MachikoroG, ctx: Ctx): void => {
  */
 const debugSetupData: SetupData = {
   version: Version.MK1,
-  expansions: [Expansion.Base],
+  expansions: [Expansion.Base, Expansion.Harbor, Expansion.Million],
   // version: Version.MK2,
   // expansions: [Expansion.Base],
   supplyVariant: SupplyVariant.Hybrid,

--- a/src/game/machikoro.ts
+++ b/src/game/machikoro.ts
@@ -1543,10 +1543,10 @@ const activatePark = (G: MachikoroG, ctx: Ctx): void => {
  */
 const debugSetupData: SetupData = {
   version: Version.MK1,
-  expansions: [Expansion.Base, Expansion.Harbor, Expansion.Million],
+  expansions: [Expansion.Base],
   // version: Version.MK2,
   // expansions: [Expansion.Base],
-  supplyVariant: SupplyVariant.Total,
+  supplyVariant: SupplyVariant.Hybrid,
   startCoins: 99,
   initialBuyRounds: 0,
   randomizeTurnOrder: false,

--- a/src/game/machikoro.ts
+++ b/src/game/machikoro.ts
@@ -1546,7 +1546,7 @@ const debugSetupData: SetupData = {
   expansions: [Expansion.Base, Expansion.Harbor, Expansion.Million],
   // version: Version.MK2,
   // expansions: [Expansion.Base],
-  supplyVariant: SupplyVariant.Hybrid,
+  supplyVariant: SupplyVariant.Total,
   startCoins: 99,
   initialBuyRounds: 0,
   randomizeTurnOrder: false,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -318,12 +318,6 @@ select {
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 */
 
-/* STACK TABLE FORMATTING */
-
-.stack-table {
-  margin: 0 auto;
-}
-
 /* ACTIONS & ITEM SELECTION */
 
 .clickable {
@@ -351,7 +345,7 @@ select {
   margin: 5px;
   padding: 2px;
   text-align: center;
-  max-width: 630px;
+  width: 630px; /* fix width to keep supply layout constant */
   white-space: nowrap;
 }
 


### PR DESCRIPTION
When using hybrid supply, the marketplace row containing 1-6 roll establishments and the row containing 7+ roll establishments no longer blend into each other, but now stay distinct. The effect is noticeable when the supply is running low.

<img width="881" alt="Screen Shot 2023-10-16 at 23 14 15" src="https://github.com/kevinddchen/machikoro/assets/79341521/6c42d356-94b4-40aa-b639-712ef00841b2">

This fixes #114 .