### PR TITLE
Fix coin text

### DIFF
--- a/src/board/PlayerInfo.tsx
+++ b/src/board/PlayerInfo.tsx
@@ -74,7 +74,8 @@ export default class PlayerInfo extends React.Component<PlayerInfoProps, object>
       if (version === Game.Version.MK1 && (clientPlayer === null || !Land.owns(G, clientPlayer, land))) {
         const landCostArray = Land.costArray(G, land, clientPlayer);
         // Machi Koro 1 only has one cost
-        landDescriptionUnparsed += '\n\nCost: ' + landCostArray[0].toString();
+        const cost = landCostArray[0];
+        landDescriptionUnparsed += `\n\nCost: ${cost} ${Game.coinPlural(cost)}`;
       }
       const landDescription = parseMaterialSymbols(landDescriptionUnparsed);
 
@@ -138,7 +139,7 @@ export default class PlayerInfo extends React.Component<PlayerInfoProps, object>
       // for Tech Startup establishment, add the current investment to the description
       if (Est.isEqual(est, Est.TechStartup)) {
         const investment = Est.getInvestment(G, player);
-        estDescriptionUnparsed = `${estDescriptionUnparsed}\n\nCurrent investment: ${investment}`;
+        estDescriptionUnparsed += `\n\nInvestment: ${investment} ${Game.coinPlural(investment)}`;
       }
 
       const estRollBoxes = formatRollBoxes(est.rolls, 'mini_roll_box');

--- a/src/board/Supply.tsx
+++ b/src/board/Supply.tsx
@@ -126,7 +126,7 @@ export default class Supply extends React.Component<SupplyProps, object> {
             <span className='material-symbols-outlined'>{est.type ? est.type.split('::').join('') : ''}</span>
           </div>
           <div className='est_name'>{est.name}</div>
-          <div className='est_cost'>${est.cost}</div>
+          <div className='est_cost'>{costToString(est.cost)}</div>
           <div className='est_num'>
             {available}/{remaining}
           </div>
@@ -147,3 +147,14 @@ export default class Supply extends React.Component<SupplyProps, object> {
     );
   }
 }
+
+/**
+ * Format a cost as a string.
+ */
+const costToString = (cost: number): string => {
+  if (cost < 0) {
+    return `\u2212$${-cost}`;
+  } else {
+    return `$${cost}`
+  }
+};

--- a/src/board/Supply.tsx
+++ b/src/board/Supply.tsx
@@ -155,6 +155,6 @@ const costToString = (cost: number): string => {
   if (cost < 0) {
     return `\u2212$${-cost}`;
   } else {
-    return `$${cost}`
+    return `$${cost}`;
   }
 };

--- a/src/game/display.ts
+++ b/src/game/display.ts
@@ -85,3 +85,11 @@ export function supplyVariantName(supplyVariant: SupplyVariant | null): string {
     return assertUnreachable(supplyVariant);
   }
 }
+
+/**
+ * @param amount
+ * @returns 'coin' if amount is 1, 'coins' otherwise.
+ */
+export const coinPlural = (amount: number): string => {
+  return amount === 1 ? 'coin' : 'coins';
+};

--- a/src/game/log/parsers.ts
+++ b/src/game/log/parsers.ts
@@ -3,6 +3,7 @@
 //
 
 import { assertUnreachable } from 'common/typescript';
+import { coinPlural } from '../display';
 
 import type { MachikoroG } from '../types';
 
@@ -97,14 +98,6 @@ export const parseLogEvent = (logEvent: LogEvent, names: string[]): string => {
   } else {
     return assertUnreachable(logEvent);
   }
-};
-
-/**
- * @param amount
- * @returns 'coin' if amount is 1, 'coins' otherwise.
- */
-const coinPlural = (amount: number): string => {
-  return amount === 1 ? 'coin' : 'coins';
 };
 
 // ----------------------------------------------------------------------------
@@ -443,7 +436,7 @@ export const logInvestTechStartup = (G: MachikoroG, newInvestment: number): void
  * (Machi Koro 1).
  */
 const parseInvestTechStartup = (logEvent: TechStartup): string => {
-  return `\tinvested in Tech Startup (total investment: ${logEvent.newInvestment})`;
+  return `\tinvested in Tech Startup (investment: ${logEvent.newInvestment} ${coinPlural(logEvent.newInvestment)})`;
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
<img width="129" alt="Screen Shot 2023-10-30 at 21 54 24" src="https://github.com/kevinddchen/machikoro/assets/79341521/946a04c8-ccd4-4fce-bac2-684ed9f35e95">

- Change `Loan Office` cost text to "-$5" (this PR fixes #132).
- Add "coin"/"coins" word for landmark cost, Tech Startup text.