### PR TITLE
Make tooltips less sticky 

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -377,6 +377,7 @@ select {
   white-space: pre-line;
   width: 140px;
   z-index: 1;
+  pointer-events: none;
 }
 
 /* font size for tooltip Material Symbols */


### PR DESCRIPTION
Previously, the tooltip was "sticky" in the sense that when your cursor hovered over an establishment/landmark and the tooltip bubble was very big, you could move your cursor over the tooltip text itself and it would not disappear, even if the tooltip bubble was covering another establishment/landmark. This caused misclicks because clicking on the tooltip bubble registers the click to the establishment/landmark the tooltip belongs to, not the establishment/landmark underneath the tooltip.

This PR makes it so that hovering over a tooltip itself does nothing special. Now tooltips disappear when the cursor leaves the underlying establishment/landmark div, as expected.

This PR resolves #135. I am surprised this problem could be fixed with a single line!