### PR TITLE
Remove silent failure when computing landmark cost

### DIFF
--- a/src/game/landmarks/main.ts
+++ b/src/game/landmarks/main.ts
@@ -135,9 +135,7 @@ export const cost = (G: MachikoroG, land: Landmark, player: number): number => {
     case Version.MK2: {
       // Machi Koro 2 landmark costs change based on the number of built landmarks
       const built = countBuilt(G, player);
-      // TODO: loud error on out of bounds
-      const costIdx = Math.min(Math.max(built, 0), land.cost.length - 1); // avoid array out of bounds
-      return landCostArray[costIdx];
+      return landCostArray[built];
     }
   }
 };


### PR DESCRIPTION
Removing a silent failure when computing the landmark cost in Machi Koro 2. Previously, the number of built landmarks was clamped to a value in `[0, 1, 2]` before looking into the array, but this may lead to unintended failures (which will be difficult to find). Instead, we will loudly error when something bad happens instead.